### PR TITLE
Fix job deletion check and strengthen test coverage

### DIFF
--- a/src/main/java/com/job/service/JobManagerService.java
+++ b/src/main/java/com/job/service/JobManagerService.java
@@ -75,7 +75,7 @@ public class JobManagerService {
         if (!JobConstant.SUCCESS_CODE.equals(checkRes)) {
             return checkRes;
         }
-        // 2.新增jonInfo
+        // 2.新增 jobInfo
         JobInfo checkJobTitle = new JobInfo();
         checkJobTitle.setTitle(jobInfoBO.getTitle());
         Long count = jobInfoMapper.selectCount(new QueryWrapper<>(checkJobTitle));

--- a/src/main/java/com/job/util/JobUtil.java
+++ b/src/main/java/com/job/util/JobUtil.java
@@ -78,9 +78,8 @@ public class JobUtil {
 
     /**
      * 获取任务下一次运行时间
-     * @param jobInfo
-     * @return
-     * @throws ParseException
+     * @param jobInfo 任务信息
+     * @return 下一次执行时间, 如果 cron 表达式非法则返回 {@code null}
      */
     public static Date getNextExecuteTime(JobInfo jobInfo) {
         if (jobInfo != null && StrUtil.isNotBlank(jobInfo.getCron())) {
@@ -95,15 +94,12 @@ public class JobUtil {
     }
 
     /**
-     * 判断该是否为已删除的任务
-     * @param jobInfo
-     * @return
+     * 判断该任务是否已删除
+     * @param jobInfo 任务信息
+     * @return true 表示任务已删除
      */
     public static boolean isDeletedJob(JobInfo jobInfo) {
-        if (jobInfo != null && !JobEnums.JobStatus.DELETED.status().equals(jobInfo.getStatus())) {
-            return false;
-        }
-        return true;
+        return jobInfo != null && JobEnums.JobStatus.DELETED.status().equals(jobInfo.getStatus());
     }
 
 }

--- a/src/test/java/com/job/HutoolTest.java
+++ b/src/test/java/com/job/HutoolTest.java
@@ -2,6 +2,7 @@ package com.job;
 
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.crypto.SecureUtil;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -13,8 +14,8 @@ public class HutoolTest {
     @Test
     public void md5() {
         String admin = StrUtil.concat(false, "admin", "123456");
-        String s = SecureUtil.md5(admin);// a66abb5684c45962d887564f08346e8d
-        System.out.println(s);
+        String s = SecureUtil.md5(admin);
+        Assertions.assertEquals("a66abb5684c45962d887564f08346e8d", s);
     }
 
 }


### PR DESCRIPTION
## Summary
- clarify next execution time Javadoc
- fix job deletion detection logic
- correct job creation comment typo
- assert expected MD5 hash in HutoolTest

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM for com.job:quartz-httpjob:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68b510a99270832d942fda4047c6167b